### PR TITLE
Add initial Helm chart for ComfyUI deployment on Kubernetes

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: comfyui-helm
+description: A Helm chart for deploying ComfyUI on Kubernetes.
+keywords:
+  - comfyui
+  - kubernetes
+  - helm
+  - ai
+  - machine-learning
+home: https://github.com/memenow/comfyui-helm.git
+sources:
+  - https://github.com/memenow/comfyui-helm
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v1.0.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,76 @@
+# Base image: NVIDIA CUDA 12.2.2 with cuDNN 8 runtime on Ubuntu 22.04
+FROM nvcr.io/nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
+
+# Install system dependencies
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    gcc \
+    g++ \
+    gdb \
+    make \
+    wget \
+    curl \
+    git \
+    vim \
+    python3 \
+    python3-pip \
+    python3-dev \
+    libgl1 \
+    libglib2.0-0 \
+    libjemalloc2 \
+    pkg-config \
+    unzip \
+    ca-certificates \
+    ffmpeg \
+    libsm6 \
+    libxext6 \
+    libgl1-mesa-glx \
+    && rm -rf /var/lib/apt/lists/* # Clean up apt cache
+
+# Set working directory
+WORKDIR /app
+
+# Clone ComfyUI repository
+RUN git clone https://github.com/comfyanonymous/ComfyUI
+
+# Change working directory to ComfyUI
+WORKDIR /app/ComfyUI
+
+# Install Python dependencies
+RUN pip3 install --no-cache-dir --upgrade pip wheel setuptools && \
+    pip3 install --no-cache-dir \
+    --extra-index-url https://download.pytorch.org/whl/nightly/cu121 \
+    --pre torch torchvision torchaudio && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    pip3 install --no-cache-dir \
+    opencv-python \
+    piexif \
+    numba \
+    evalidate \
+    accelerate \
+    matplotlib \
+    imageio-ffmpeg \
+    gguf \
+    GitPython \
+    opencv-python-headless
+
+# Set environment variables
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics \
+    LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+    PYTHONPATH="${PYTHONPATH}:/app/ComfyUI" \
+    TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6+PTX" \
+    NVIDIA_VISIBLE_DEVICES=all
+
+# Set execute permissions on the ComfyUI directory
+RUN chmod -R 755 /app/ComfyUI
+
+# Expose port 8188
+EXPOSE 8188
+
+# Run ComfyUI
+CMD ["python3", "main.py", \
+    "--cuda-malloc", \
+    "--use-pytorch-cross-attention", \
+    "--listen", "0.0.0.0", \
+    "--port", "8188"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,141 @@
+# ComfyUI Helm Chart
+
+This Helm chart deploys [ComfyUI](https://github.com/comfyanonymous/ComfyUI), a powerful and modular Stable Diffusion GUI, on Kubernetes. The project is open source and welcomes community contributions.
+
+## Overview
+
+The Helm chart is optimized for deploying ComfyUI with GPU support on Kubernetes clusters. It integrates seamlessly with a provided Dockerfile, which builds a CUDA-enabled container image based on Ubuntu 22.04, ensuring optimal performance for ComfyUI.
+
+## Key Features
+
+- **Dockerfile Integration:**  
+  - Builds ComfyUI from the official repository.
+  - Installs necessary system and Python dependencies.
+  - Configures essential environment variables (`NVIDIA_DRIVER_CAPABILITIES`, `LD_PRELOAD`, `PYTHONPATH`, `TORCH_CUDA_ARCH_LIST`, `NVIDIA_VISIBLE_DEVICES`).
+  - Runs ComfyUI server with optimized settings:
+    ```
+    python3 main.py --cuda-malloc --use-pytorch-cross-attention --listen 0.0.0.0 --port 8188
+    ```
+
+- **Kubernetes Optimized:**
+  - Deploys Kubernetes resources: Deployment, Service, Ingress, HPA, ServiceAccount.
+  - Enables NVIDIA GPU support.
+  - Exposes application on port 8188.
+  - Uses a dynamically generated service account name (`{{ .Release.Name }}-sa` by default).
+
+- **Customizable Image Settings:**  
+  Adjust Docker image details in `values.yaml`:
+  ```
+  image:
+    repository: your-registry/comfyui-helm
+    tag: your-tag
+    pullPolicy: IfNotPresent
+  ```
+
+- **Flexible Service Exposure:**  
+  Supports ClusterIP, NodePort, LoadBalancer, and Ingress types.
+
+## Prerequisites
+
+- Kubernetes cluster with NVIDIA GPU nodes.
+- Helm v3 installed.
+- Docker installed for image building.
+
+## Installing and Upgrading the Helm Chart
+
+1. **Configure Chart Version:**  
+   Set ComfyUI version in `Chart.yaml` (`appVersion`) and optionally add an icon URL.
+
+2. **Update Image Details:**  
+   Modify `values.yaml`:
+   ```
+   image:
+     repository: your-registry/comfyui-helm
+     tag: your-tag
+     pullPolicy: IfNotPresent
+   ```
+
+3. **Lint Chart (Optional):**
+   ```
+   helm lint .
+   ```
+
+4. **Deploy or Upgrade Chart:**
+
+   Install:
+   ```
+   helm install comfyui-helm . --set image.repository=your-registry/comfyui-helm,image.tag=your-tag
+   ```
+
+   Upgrade existing deployment:
+   ```
+   helm upgrade comfyui-helm . --set image.repository=your-registry/comfyui-helm,image.tag=your-tag
+   ```
+   
+5. **Horizontal Pod Autoscaler (HPA):**
+   - HPA is enabled by default, scaling the number of pods based on CPU utilization.
+   - You can configure HPA settings in `values.yaml`:
+     ```
+     autoscaling:
+       enabled: true
+       minReplicas: 1
+       maxReplicas: 100
+       targetCPUUtilizationPercentage: 80
+     ```
+   - To disable HPA, set `autoscaling.enabled` to `false`.
+
+6. **Service Exposure Options:**
+   - **ClusterIP:** Default internal access; use port-forwarding externally.
+   - **NodePort:** Exposes service externally on node ports.
+   - **LoadBalancer:** Automatically provisions external IP if supported.
+   - **Ingress:** Enable and configure ingress in `values.yaml`.
+
+## Accessing ComfyUI
+
+### ClusterIP (Port Forwarding)
+
+```
+export POD_NAME=$(kubectl get pods -l "app.kubernetes.io/name=comfyui-helm" -o jsonpath="{.items.metadata.name}")
+kubectl port-forward $POD_NAME 8188:8188
+```
+Visit [http://127.0.0.1:8188](http://127.0.0.1:8188).
+
+### NodePort
+
+Retrieve NodePort number:
+
+```
+kubectl get svc comfyui-helm -o=jsonpath='{.spec.ports[?(@.name=="http")].nodePort}'
+```
+Access via `http://:`.
+
+### LoadBalancer
+
+Get external IP:
+
+```
+kubectl get svc comfyui-helm -o=jsonpath='{.status.loadBalancer.ingress.ip}'
+```
+Access via external IP at port 8188.
+
+### Ingress
+
+Configure ingress in `values.yaml`, ensure DNS setup, then access using configured hostname.
+
+## Testing the Chart
+
+Run provided tests:
+
+```
+helm test comfyui-helm
+```
+
+## Contributing
+
+This project is open source—contributions are encouraged! Fork the repository, submit issues or feature requests, and create pull requests to improve this Helm chart.
+
+See the [LICENSE](LICENSE) file for licensing details.
+
+## About ComfyUI
+
+For more information on ComfyUI, visit the official [ComfyUI GitHub repository](https://github.com/comfyanonymous/ComfyUI).

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,0 +1,30 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your ComfyUI instance is now deploying. This may take a few minutes depending on your environment.
+
+{{- if contains "NodePort" .Values.service.type }}
+Get the application URL by running these commands:
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "comfyui-helm.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+Get the application URL by running these commands:
+   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+         You can watch the status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "comfyui-helm.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "comfyui-helm.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+Access your ComfyUI instance using kubectl port-forward:
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "comfyui-helm.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  Then access ComfyUI at: http://localhost:{{ .Values.service.port }}
+
+{{- end }}
+
+{{- if .Values.ingress.enabled }}
+Your ComfyUI instance can also be accessed through the ingress at:
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "comfyui-helm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "comfyui-helm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "comfyui-helm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "comfyui-helm.labels" -}}
+helm.sh/chart: {{ include "comfyui-helm.chart" . }}
+{{ include "comfyui-helm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "comfyui-helm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "comfyui-helm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "comfyui-helm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "comfyui-helm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,0 +1,80 @@
+{{- /*
+This template defines the Kubernetes Deployment for ComfyUI.
+It uses values from values.yaml to configure the deployment.
+*/ -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "comfyui-helm.fullname" . }}
+  labels:
+    {{- include "comfyui-helm.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }} # Number of pod replicas.
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "comfyui-helm.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "comfyui-helm.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "comfyui-helm.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }} # Container port.
+              protocol: TCP
+          {{- if .Values.environment }}
+          env:
+            {{- range $key, $value := .Values.environment }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "comfyui-helm.fullname" . }}
+  labels:
+    {{- include "comfyui-helm.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "comfyui-helm.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "comfyui-helm.fullname" . }}
+  labels:
+    {{- include "comfyui-helm.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "comfyui-helm.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- /*
+This template defines the Kubernetes Service for ComfyUI.
+It exposes the ComfyUI application on the specified port.
+*/ -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "comfyui-helm.fullname" . }}
+  labels:
+    {{- include "comfyui-helm.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }} # Service type (e.g., ClusterIP, NodePort, LoadBalancer).
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "comfyui-helm.selectorLabels" . | nindent 4 }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "comfyui-helm.serviceAccountName" . }}
+  labels:
+    {{- include "comfyui-helm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.serviceAccount.automount }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+  {{- end }}
+{{- end }}

--- a/templates/tests/test-connection.yaml
+++ b/templates/tests/test-connection.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "comfyui-helm-test-connection"
+  labels:
+    app.kubernetes.io/name: "comfyui-helm"
+    helm.sh/hook: test
+spec:
+  containers:
+    - name: curl
+      image: curlimages/curl:8.1.2
+      command:
+        - sh
+        - -c
+        - |
+          # Wait a few seconds for service startup before testing.
+          sleep 5
+          # Test HTTP connection to ComfyUI service on port 8188.
+          curl -s --fail http://{{ include "comfyui-helm.fullname" . }}:8188 || exit 1
+  restartPolicy: Never

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,115 @@
+# Number of pod replicas.
+replicaCount: 1
+
+# Container image settings.
+image:
+  repository: comfyui-helm # Placeholder, user will build and tag locally.
+  pullPolicy: IfNotPresent # Pull policy for the image.
+  tag: "{{ .Chart.AppVersion }}" # Image tag. Defaults to the chart's appVersion.
+
+# Image pull secrets (if using a private registry).
+imagePullSecrets: []
+# Overrides the chart name.
+nameOverride: ""
+# Overrides the full chart name.
+fullnameOverride: ""
+
+# Service account configuration.
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: true
+  # Automatically mount a ServiceAccount's API credentials.
+  automount: true
+  # Annotations to add to the service account.
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name: "{{ .Release.Name }}-sa"
+
+# Pod annotations.
+podAnnotations:
+  # This annotation is required for NVIDIA GPUs to be detected correctly.
+  nvidia.com/gpu.capabilities: "compute,utility,graphics"
+# Pod labels.
+podLabels: {}
+
+# Kubernetes service configuration.
+service:
+  type: ClusterIP  # Service type (ClusterIP, NodePort, LoadBalancer).
+  port: 8188      # Service port.
+  nodePort: ""    # Optional: Specify a NodePort (only used if type is NodePort).
+
+# Ingress configuration (for external access).
+ingress:
+  enabled: false  # Enable or disable Ingress.
+  className: ""   # Ingress class name (if required by your Ingress controller).
+  annotations: {}  # Annotations for the Ingress resource.
+    # Example:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:          # Hostname configuration.
+    - host: chart-example.local  # Replace with your desired hostname.
+      paths:
+        - path: /                # Path to expose.
+          pathType: ImplementationSpecific # Path type (ImplementationSpecific, Prefix, Exact).
+  tls: []  # TLS configuration (if using HTTPS).
+  # Example:
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# Resource requests and limits.
+resources:
+  limits:
+    nvidia.com/gpu: 1 # Limit to 1 NVIDIA GPU.
+  requests:
+    cpu: "4" # Request 4 CPU cores.
+    memory: "16Gi" # Request 16GB of RAM.
+    nvidia.com/gpu: 1 # Request 1 NVIDIA GPU.
+
+# Liveness and readiness probes.
+livenessProbe:
+  tcpSocket: # Use a TCP socket check for liveness.
+    port: 8188
+readinessProbe:
+  tcpSocket: # Use a TCP socket check for readiness.
+    port: 8188
+
+# Horizontal Pod Autoscaler (HPA) configuration.
+autoscaling:
+  enabled: true # Enable or disable HPA.
+  minReplicas: 1 # Minimum number of replicas.
+  maxReplicas: 100 # Maximum number of replicas.
+  targetCPUUtilizationPercentage: 80 # Target CPU utilization percentage.
+  # targetMemoryUtilizationPercentage: 80 # Target memory utilization percentage.
+
+# Additional volumes.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volume mounts.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+# Environment variables for the ComfyUI container.
+environment:
+  NVIDIA_DRIVER_CAPABILITIES: compute,utility,graphics # NVIDIA driver capabilities.
+  LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 # Preload jemalloc for memory management.
+  PYTHONPATH: "${PYTHONPATH}:/app/ComfyUI" # Add ComfyUI to the Python path.
+  TORCH_CUDA_ARCH_LIST: "7.0;7.5;8.0;8.6+PTX" # CUDA architectures for Torch.
+  NVIDIA_VISIBLE_DEVICES: all # Make all NVIDIA devices visible.
+
+# Node selector (for scheduling pods on specific nodes).
+nodeSelector:
+  nvidia.com/gpu: "true" # Requires nodes with NVIDIA GPUs.
+
+# Tolerations (for scheduling pods on nodes with taints).
+tolerations: []
+
+# Affinity (for pod scheduling preferences).
+affinity: {}


### PR DESCRIPTION
This pull request introduces a Helm chart for deploying ComfyUI on Kubernetes, including a Dockerfile for building a CUDA-enabled container image. The key changes involve adding necessary configuration files and templates for Kubernetes deployment, service, and ingress, as well as documentation updates.

### Helm Chart and Kubernetes Configuration:

* **Helm Chart Configuration**:
  * [`Chart.yaml`](diffhunk://#diff-d954583aa4c24cff0039bc948abd7c694fc3dab2030231d11ed1b3cda9b4ddbeR1-R25): Added metadata for the Helm chart, including `apiVersion`, `name`, `description`, `keywords`, `home`, `sources`, `type`, `version`, and `appVersion`.
  * [`values.yaml`](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eR1-R115): Defined default values for the Helm chart, including replica count, image settings, service account, pod annotations, service type, ingress settings, resource requests, and autoscaling configuration.

* **Kubernetes Resource Templates**:
  * [`templates/deployment.yaml`](diffhunk://#diff-7792a5fea7287a039634c3c2ee77f1b23d7fcd8b8f6e225446a9e5456dd77a38R1-R80): Defined the Kubernetes Deployment for ComfyUI, specifying the container image, ports, environment variables, and resource requests.
  * [`templates/service.yaml`](diffhunk://#diff-e5a380da347857c64956e332ead88f36f1d1b3f1a95b0dffadad581506930d17R1-R22): Defined the Kubernetes Service to expose the ComfyUI application, specifying the service type and port.
  * [`templates/ingress.yaml`](diffhunk://#diff-612d87a9a43b4e6ad348a1ad96e963734289a06ecd01902e82c3b03201fb9874R1-R43): Defined the Kubernetes Ingress resource for external access to the ComfyUI application, including annotations and TLS configuration.

### Dockerfile and Documentation:

* **Dockerfile**:
  * [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R76): Added a Dockerfile to build a CUDA-enabled container image for ComfyUI, including installation of system dependencies, cloning the ComfyUI repository, and setting environment variables.

* **Documentation**:
  * [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R141): Added detailed documentation for the Helm chart, including an overview, key features, prerequisites, installation instructions, and access methods.

### Additional Templates and Helper Functions:

* **Helper Functions**:
  * [`templates/_helpers.tpl`](diffhunk://#diff-87d68c754766af8e2e930e653be7e4b75fa0c8bdb187cb1bec293f265d9159ffR1-R62): Added helper functions for generating names, labels, and service account names used in the Kubernetes resource templates.

* **Miscellaneous Templates**:
  * [`templates/NOTES.txt`](diffhunk://#diff-eb6050bb15aacaa13a6676d57919221967ae8394ecc82805b8bd1543c0881944R1-R30): Added a template for post-installation notes, providing instructions for accessing the ComfyUI application based on the service type.
  * [`templates/serviceaccount.yaml`](diffhunk://#diff-6bde81bcd3adb07b5902e1482849387e9a6f20d2de9346b378e4c87f7a76dc36R1-R15): Added a template for creating a Kubernetes ServiceAccount if specified in the values.
  * [`templates/hpa.yaml`](diffhunk://#diff-fc34b688c01ef7e4aa35f9b7a47a058d106363d7eca33796ee863b4cbeab2544R1-R30): Added a template for configuring a Horizontal Pod Autoscaler (HPA) if enabled.
  * [`templates/tests/test-connection.yaml`](diffhunk://#diff-e717f8763feaf34081f7215ef0388559cf3b5fdb60db18750e2ebcaabb1d4af8R1-R20): Added a test template to verify the HTTP connection to the ComfyUI service.

These changes collectively enable the deployment, management, and scaling of ComfyUI on Kubernetes using Helm.